### PR TITLE
Add /testapp to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,4 @@ phpunit.xml              export-ignore
 CHANGELOG.md             export-ignore
 CONTRIBUTING.md          export-ignore
 README.md                export-ignore
+/testapp                 export-ignore


### PR DESCRIPTION
Tested the package with the `/testapp` removed from vendor and it functioned as advertised. Thus this PR adds the `/testapp` folder to the `.gitattributes` file.

Preventing it from being downloaded when the package is required, saving both bandwidth and space for the end-user.