### PR TITLE
Add Pest v2.0 support

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: 7.4
+        php-version: 8.1
         tools: composer:v2
         coverage: none
 
@@ -40,7 +40,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: 7.4
+        php-version: 8.1
         tools: composer:v2
         coverage: none
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        php: ['7.4', '8.0', '8.1']
+        php: ['8.1', '8.2']
 
     name: PHP ${{ matrix.php }} - ${{ matrix.os }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Increased `pestphp/pest` requirement from ^1.20 to ^2.0
 - Increased `pest-dev-tools` requirement from `dev-master` to ^2.0
 - Increased `pestphp/pest-plugin` requirement from ^1.0 to ^2.0
+- Updated requirement for php version to `8.1` and `8.2`
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- Added dependency `friendsofphp/php-cs-fixer` in composer.jon
+
+### Changed
+
+- Increased `laravel/framework` requirement from ^v8.64 to ^10.0
+- Increased `orchestra/testbench` requirement from ^6.21 to ^8.0
+- Increased `pestphp/pest` requirement from ^1.20 to ^2.0
+- Increased `pest-dev-tools` requirement from `dev-master` to ^2.0
+- Increased `pestphp/pest-plugin` requirement from ^1.0 to ^2.0
+
+### Removed
+
+- Removed the `processUncoveredFiles` attribute on the `<coverage>` phpunit.xml configuration element
+- Removed `fruitcake/laravel-cors` dependency
+
 ## [v0.2.0](https://github.com/lukeraymonddowning/pest-plugin-larastrap/releases/tag/v0.2.0)
 
 Added:

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^7.4 || ^8.0 || ^8.1",
+        "php": "^8.1 || ^8.2",
         "pestphp/pest-plugin": "^2.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.4 || ^8.0 || ^8.1",
-        "pestphp/pest-plugin": "^1.0"
+        "pestphp/pest-plugin": "^2.0"
     },
     "autoload": {
         "psr-4": {
@@ -21,10 +21,11 @@
         }
     },
     "require-dev": {
-        "laravel/framework": "^8.64",
-        "orchestra/testbench": "^6.21",
-        "pestphp/pest": "^1.20",
-        "pestphp/pest-dev-tools": "dev-master"
+        "friendsofphp/php-cs-fixer": "^3.15",
+        "laravel/framework": "^10.0",
+        "orchestra/testbench": "^8.0",
+        "pestphp/pest": "^2.0",
+        "pestphp/pest-dev-tools": "^2.0"
     },
     "extra": {
         "pest": {
@@ -40,7 +41,10 @@
     "prefer-stable": true,
     "config": {
         "sort-packages": true,
-        "preferred-install": "dist"
+        "preferred-install": "dist",
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
     },
     "scripts": {
         "lint": "php-cs-fixer fix -v",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,7 @@
             <directory suffix=".php">./tests</directory>
         </testsuite>
     </testsuites>
-    <coverage processUncoveredFiles="true">
+    <coverage>
         <include>
             <directory suffix=".php">./src</directory>
         </include>

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Lukeraymonddowning\Larastrap;
 
-use BadMethodCallException;
 use Pest\Contracts\Plugins\HandlesArguments;
 use Tests\CreatesApplication;
 
@@ -16,7 +15,7 @@ final class Plugin implements HandlesArguments
     public function handleArguments(array $arguments): array
     {
         if (!trait_exists(CreatesApplication::class)) {
-            throw new BadMethodCallException('You must have a Tests\\CreatesApplication trait available in your Laravel project to use the Larastrap plugin.');
+            throw new \BadMethodCallException('You must have a Tests\\CreatesApplication trait available in your Laravel project to use the Larastrap plugin.');
         }
 
         (new class() {

--- a/testapp/app/Http/Kernel.php
+++ b/testapp/app/Http/Kernel.php
@@ -16,7 +16,7 @@ class Kernel extends HttpKernel
     protected $middleware = [
         // \App\Http\Middleware\TrustHosts::class,
         \App\Http\Middleware\TrustProxies::class,
-        \Fruitcake\Cors\HandleCors::class,
+        \Illuminate\Http\Middleware\HandleCors::class,
         \App\Http\Middleware\PreventRequestsDuringMaintenance::class,
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
         \App\Http\Middleware\TrimStrings::class,

--- a/testapp/app/Http/Kernel.php
+++ b/testapp/app/Http/Kernel.php
@@ -11,7 +11,7 @@ class Kernel extends HttpKernel
      *
      * These middleware are run during every request to your application.
      *
-     * @var array
+     * @var array<int, class-string|string>
      */
     protected $middleware = [
         // \App\Http\Middleware\TrustHosts::class,
@@ -26,14 +26,13 @@ class Kernel extends HttpKernel
     /**
      * The application's route middleware groups.
      *
-     * @var array
+     * @var array<string, array<int, class-string|string>>
      */
     protected $middlewareGroups = [
         'web' => [
             \App\Http\Middleware\EncryptCookies::class,
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
             \Illuminate\Session\Middleware\StartSession::class,
-            // \Illuminate\Session\Middleware\AuthenticateSession::class,
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             \App\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
@@ -41,26 +40,27 @@ class Kernel extends HttpKernel
 
         'api' => [
             // \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
-            'throttle:api',
+            \Illuminate\Routing\Middleware\ThrottleRequests::class.':api',
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ],
     ];
 
     /**
-     * The application's route middleware.
+     * The application's middleware aliases.
      *
-     * These middleware may be assigned to groups or used individually.
+     * Aliases may be used to conveniently assign middleware to routes and groups.
      *
-     * @var array
+     * @var array<string, class-string|string>
      */
-    protected $routeMiddleware = [
+    protected $middlewareAliases = [
         'auth' => \App\Http\Middleware\Authenticate::class,
         'auth.basic' => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
+        'auth.session' => \Illuminate\Session\Middleware\AuthenticateSession::class,
         'cache.headers' => \Illuminate\Http\Middleware\SetCacheHeaders::class,
         'can' => \Illuminate\Auth\Middleware\Authorize::class,
         'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
         'password.confirm' => \Illuminate\Auth\Middleware\RequirePassword::class,
-        'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
+        'signed' => \App\Http\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
     ];

--- a/testapp/composer.json
+++ b/testapp/composer.json
@@ -5,7 +5,7 @@
     "keywords": ["framework", "laravel"],
     "license": "MIT",
     "require": {
-        "php": "^7.3|^8.0|^8.1",
+        "php": "^8.1 || ^8.2",
         "guzzlehttp/guzzle": "^7.0.1",
         "laravel/framework": "^10.0",
         "laravel/sanctum": "^3.2",

--- a/testapp/composer.json
+++ b/testapp/composer.json
@@ -6,21 +6,19 @@
     "license": "MIT",
     "require": {
         "php": "^7.3|^8.0|^8.1",
-        "fruitcake/laravel-cors": "^2.0",
         "guzzlehttp/guzzle": "^7.0.1",
-        "laravel/framework": "^8.54",
-        "laravel/sanctum": "^2.11",
-        "laravel/tinker": "^2.5"
+        "laravel/framework": "^10.0",
+        "laravel/sanctum": "^3.2",
+        "laravel/tinker": "^2.0"
     },
     "require-dev": {
-        "facade/ignition": "^2.5",
+        "spatie/laravel-ignition": "^2.0",
         "fakerphp/faker": "^1.9.1",
-        "laravel/sail": "^1.0.1",
+        "laravel/sail": "^1.0",
         "lukeraymonddowning/pest-plugin-larastrap": "1.x-dev",
         "mockery/mockery": "^1.4.4",
-        "nunomaduro/collision": "^5.10",
-        "pestphp/pest": "^1.20",
-        "phpunit/phpunit": "^9.5.8"
+        "nunomaduro/collision": "^7.0",
+        "pestphp/pest": "^2.0"
     },
     "autoload": {
         "psr-4": {
@@ -57,7 +55,10 @@
     "config": {
         "optimize-autoloader": true,
         "preferred-install": "dist",
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/testapp/phpunit.xml
+++ b/testapp/phpunit.xml
@@ -9,7 +9,7 @@
             <directory suffix="Test.php">./tests/Feature</directory>
         </testsuite>
     </testsuites>
-    <coverage processUncoveredFiles="true">
+    <coverage>
         <include>
             <directory suffix=".php">./app</directory>
         </include>


### PR DESCRIPTION
All the main things I did in this PR is contained inside CHANGELOG.md 'Unreleased' section.

## What I've changed?

- Updated dependencies
- Removed unmantained dependencies
- Removed the `processUncoveredFiles` attribute on the `<coverage>` phpunit.xml configuration element. Because it's no longer supported.

## Notes

1. The main goal of this PR was to update the Pest version used by the package.
2. I could only have a sucessfully test run using Laravel 10... so the new requirement should probably specify this change.
3. I noticed that the supported php versions is kinda odd, I was thinking in including the 8.2... but that's for another PR.